### PR TITLE
http and metric catcher host settings

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -24,6 +24,7 @@ Metric cacher
 Graphouse support [graphite plaintext protocol](http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol)
 
 ```properties
+graphouse.cacher.host=localhost
 graphouse.cacher.port=2003
 graphouse.cacher.threads=100
 graphouse.cacher.socket-timeout-millis=42000

--- a/doc/config.md
+++ b/doc/config.md
@@ -24,7 +24,7 @@ Metric cacher
 Graphouse support [graphite plaintext protocol](http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol)
 
 ```properties
-graphouse.cacher.host=0.0.0.0
+graphouse.cacher.bind-address=::
 graphouse.cacher.port=2003
 graphouse.cacher.threads=100
 graphouse.cacher.socket-timeout-millis=42000

--- a/doc/config.md
+++ b/doc/config.md
@@ -24,7 +24,7 @@ Metric cacher
 Graphouse support [graphite plaintext protocol](http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol)
 
 ```properties
-graphouse.cacher.host=localhost
+graphouse.cacher.host=0.0.0.0
 graphouse.cacher.port=2003
 graphouse.cacher.threads=100
 graphouse.cacher.socket-timeout-millis=42000

--- a/docker/graphouse/run.sh
+++ b/docker/graphouse/run.sh
@@ -46,7 +46,7 @@ graphouse.clickhouse.query-timeout-seconds=${GH__CLICKHOUSE__QUERY_TIMEOUT_SECON
 graphouse.clickhouse.retention-config=${GH__CLICKHOUSE__RETENTION_CONFIG:=}
 
 #metric server and cacher
-graphouse.cacher.host=${GH__CACHER__HOST:=localhost}
+graphouse.cacher.host=${GH__CACHER__HOST:=0.0.0.0}
 graphouse.cacher.port=${GH__CACHER__PORT:=2003}
 graphouse.cacher.threads=${GH__CACHER__THREADS:=100}
 graphouse.cacher.socket-timeout-millis=${GH__CACHER__SOCKET_TIMEOUT_MILLIS:=42000}

--- a/docker/graphouse/run.sh
+++ b/docker/graphouse/run.sh
@@ -57,7 +57,7 @@ graphouse.cacher.writers-count=${GH__CACHER__WRITERS_COUNT:=2}
 graphouse.cacher.flush-interval-seconds=${GH__CACHER__FLUSH_INTERVAL_SECONDS:=5}
 
 #Http server (metric search, ping, metricData)
-graphouse.http.host=${GH__HTTP__HOST:=localhost}
+graphouse.http.host=${GH__HTTP__HOST:=::}
 graphouse.http.port=${GH__HTTP__PORT:=2005}
 graphouse.http.threads=${GH__HTTP__THREADS:=25}
 

--- a/docker/graphouse/run.sh
+++ b/docker/graphouse/run.sh
@@ -46,6 +46,7 @@ graphouse.clickhouse.query-timeout-seconds=${GH__CLICKHOUSE__QUERY_TIMEOUT_SECON
 graphouse.clickhouse.retention-config=${GH__CLICKHOUSE__RETENTION_CONFIG:=}
 
 #metric server and cacher
+graphouse.cacher.host=${GH__CACHER__HOST:=localhost}
 graphouse.cacher.port=${GH__CACHER__PORT:=2003}
 graphouse.cacher.threads=${GH__CACHER__THREADS:=100}
 graphouse.cacher.socket-timeout-millis=${GH__CACHER__SOCKET_TIMEOUT_MILLIS:=42000}
@@ -56,6 +57,7 @@ graphouse.cacher.writers-count=${GH__CACHER__WRITERS_COUNT:=2}
 graphouse.cacher.flush-interval-seconds=${GH__CACHER__FLUSH_INTERVAL_SECONDS:=5}
 
 #Http server (metric search, ping, metricData)
+graphouse.http.host=${GH__HTTP__HOST:=localhost}
 graphouse.http.port=${GH__HTTP__PORT:=2005}
 graphouse.http.threads=${GH__HTTP__THREADS:=25}
 

--- a/docker/graphouse/run.sh
+++ b/docker/graphouse/run.sh
@@ -31,7 +31,7 @@ generate_properties() {
 graphouse.allow-cold-run=${GH__ALLOW_COLD_RUN:=false}
 
 #Clickhouse
-graphouse.clickhouse.host=${GH__CLICKHOUSE__HOST:=localhost}
+graphouse.clickhouse.bind-address=${GH__CLICKHOUSE__BIND_ADDRESS:=::}
 graphouse.clickhouse.port=${GH__CLICKHOUSE__PORT:=8123}
 graphouse.clickhouse.db=${GH__CLICKHOUSE__DB:=graphite}
 graphouse.clickhouse.user=${GH__CLICKHOUSE__USER:=}
@@ -46,7 +46,7 @@ graphouse.clickhouse.query-timeout-seconds=${GH__CLICKHOUSE__QUERY_TIMEOUT_SECON
 graphouse.clickhouse.retention-config=${GH__CLICKHOUSE__RETENTION_CONFIG:=}
 
 #metric server and cacher
-graphouse.cacher.host=${GH__CACHER__HOST:=0.0.0.0}
+graphouse.cacher.host=${GH__CACHER__HOST:=::}
 graphouse.cacher.port=${GH__CACHER__PORT:=2003}
 graphouse.cacher.threads=${GH__CACHER__THREADS:=100}
 graphouse.cacher.socket-timeout-millis=${GH__CACHER__SOCKET_TIMEOUT_MILLIS:=42000}

--- a/docker/graphouse/run.sh
+++ b/docker/graphouse/run.sh
@@ -31,7 +31,7 @@ generate_properties() {
 graphouse.allow-cold-run=${GH__ALLOW_COLD_RUN:=false}
 
 #Clickhouse
-graphouse.clickhouse.bind-address=${GH__CLICKHOUSE__BIND_ADDRESS:=::}
+graphouse.clickhouse.host=${GH__CLICKHOUSE__HOST:=localhost}
 graphouse.clickhouse.port=${GH__CLICKHOUSE__PORT:=8123}
 graphouse.clickhouse.db=${GH__CLICKHOUSE__DB:=graphite}
 graphouse.clickhouse.user=${GH__CLICKHOUSE__USER:=}
@@ -46,7 +46,7 @@ graphouse.clickhouse.query-timeout-seconds=${GH__CLICKHOUSE__QUERY_TIMEOUT_SECON
 graphouse.clickhouse.retention-config=${GH__CLICKHOUSE__RETENTION_CONFIG:=}
 
 #metric server and cacher
-graphouse.cacher.host=${GH__CACHER__HOST:=::}
+graphouse.cacher.bind-address=${GH__CACHER__BIND_ADDRESS:=::}
 graphouse.cacher.port=${GH__CACHER__PORT:=2003}
 graphouse.cacher.threads=${GH__CACHER__THREADS:=100}
 graphouse.cacher.socket-timeout-millis=${GH__CACHER__SOCKET_TIMEOUT_MILLIS:=42000}
@@ -57,7 +57,7 @@ graphouse.cacher.writers-count=${GH__CACHER__WRITERS_COUNT:=2}
 graphouse.cacher.flush-interval-seconds=${GH__CACHER__FLUSH_INTERVAL_SECONDS:=5}
 
 #Http server (metric search, ping, metricData)
-graphouse.http.host=${GH__HTTP__HOST:=::}
+graphouse.http.bind-address=${GH__HTTP__BIND_ADDRESS:=::}
 graphouse.http.port=${GH__HTTP__PORT:=2005}
 graphouse.http.threads=${GH__HTTP__THREADS:=25}
 

--- a/src/main/java/ru/yandex/market/graphouse/GraphouseWebServer.java
+++ b/src/main/java/ru/yandex/market/graphouse/GraphouseWebServer.java
@@ -26,8 +26,8 @@ public class GraphouseWebServer {
     @Value("${graphouse.http.port}")
     private int httpPort;
     
-    @Value("${graphouse.http.host}")
-    private String httpHost;
+    @Value("${graphouse.http.bind-address}")
+    private String httpBindAddress;
 
     @Value("${graphouse.http.threads}")
     private int threadCount;
@@ -51,7 +51,7 @@ public class GraphouseWebServer {
         Server server = new Server(new QueuedThreadPool(threadCount));
         ServerConnector serverConnector = new ServerConnector(server);
         serverConnector.setPort(httpPort);
-        serverConnector.setHost(httpHost);
+        serverConnector.setHost(httpBindAddress);
         server.setConnectors(new Connector[]{serverConnector});
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");

--- a/src/main/java/ru/yandex/market/graphouse/GraphouseWebServer.java
+++ b/src/main/java/ru/yandex/market/graphouse/GraphouseWebServer.java
@@ -25,6 +25,9 @@ public class GraphouseWebServer {
 
     @Value("${graphouse.http.port}")
     private int httpPort;
+    
+    @Value("${graphouse.http.host}")
+    private String httpHost;
 
     @Value("${graphouse.http.threads}")
     private int threadCount;
@@ -48,6 +51,7 @@ public class GraphouseWebServer {
         Server server = new Server(new QueuedThreadPool(threadCount));
         ServerConnector serverConnector = new ServerConnector(server);
         serverConnector.setPort(httpPort);
+        serverConnector.setHost(httpHost);
         server.setConnectors(new Connector[]{serverConnector});
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");

--- a/src/main/java/ru/yandex/market/graphouse/server/MetricServer.java
+++ b/src/main/java/ru/yandex/market/graphouse/server/MetricServer.java
@@ -32,8 +32,8 @@ public class MetricServer implements InitializingBean {
     @Value("${graphouse.cacher.port}")
     private int port;
     
-    @Value("${graphouse.cacher.host}")
-    private String host;
+    @Value("${graphouse.cacher.bind-address}")
+    private String bindAddress;
 
     @Value("${graphouse.cacher.socket-timeout-millis}")
     private int socketTimeoutMillis;
@@ -60,7 +60,7 @@ public class MetricServer implements InitializingBean {
     public void afterPropertiesSet() throws Exception {
         log.info("Starting metric server on port: " + port);
         serverSocket = new ServerSocket();
-        SocketAddress socketAddress = new InetSocketAddress(host, port);
+        SocketAddress socketAddress = new InetSocketAddress(bindAddress, port);
         serverSocket.bind(socketAddress);
 
         log.info("Starting " + threadCount + " metric server threads");

--- a/src/main/java/ru/yandex/market/graphouse/server/MetricServer.java
+++ b/src/main/java/ru/yandex/market/graphouse/server/MetricServer.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +31,9 @@ public class MetricServer implements InitializingBean {
 
     @Value("${graphouse.cacher.port}")
     private int port;
+    
+    @Value("${graphouse.cacher.host}")
+    private String host;
 
     @Value("${graphouse.cacher.socket-timeout-millis}")
     private int socketTimeoutMillis;
@@ -54,7 +59,9 @@ public class MetricServer implements InitializingBean {
     @Override
     public void afterPropertiesSet() throws Exception {
         log.info("Starting metric server on port: " + port);
-        serverSocket = new ServerSocket(port);
+        serverSocket = new ServerSocket();
+        SocketAddress socketAddress = new InetSocketAddress(host, port);
+        serverSocket.bind(socketAddress);
 
         log.info("Starting " + threadCount + " metric server threads");
         executorService = Executors.newFixedThreadPool(threadCount);

--- a/src/main/resources/graphouse-default.properties
+++ b/src/main/resources/graphouse-default.properties
@@ -17,7 +17,7 @@ graphouse.clickhouse.query-timeout-seconds=120
 graphouse.clickhouse.retention-config=
 
 #metric server and cacher
-graphouse.cacher.host=0.0.0.0
+graphouse.cacher.bind-address=::
 graphouse.cacher.port=2003
 graphouse.cacher.threads=100
 graphouse.cacher.socket-timeout-millis=42000
@@ -31,7 +31,7 @@ graphouse.cacher.max-batch-time-seconds=5
 graphouse.cacher.max-output-threads=5
 
 #Http server (metric search, ping, metricData)
-graphouse.http.host=localhost
+graphouse.http.host=::
 graphouse.http.port=2005
 graphouse.http.threads=25
 

--- a/src/main/resources/graphouse-default.properties
+++ b/src/main/resources/graphouse-default.properties
@@ -17,6 +17,7 @@ graphouse.clickhouse.query-timeout-seconds=120
 graphouse.clickhouse.retention-config=
 
 #metric server and cacher
+graphouse.cacher.host=localhost
 graphouse.cacher.port=2003
 graphouse.cacher.threads=100
 graphouse.cacher.socket-timeout-millis=42000
@@ -30,6 +31,7 @@ graphouse.cacher.max-batch-time-seconds=5
 graphouse.cacher.max-output-threads=5
 
 #Http server (metric search, ping, metricData)
+graphouse.http.host=localhost
 graphouse.http.port=2005
 graphouse.http.threads=25
 

--- a/src/main/resources/graphouse-default.properties
+++ b/src/main/resources/graphouse-default.properties
@@ -17,7 +17,7 @@ graphouse.clickhouse.query-timeout-seconds=120
 graphouse.clickhouse.retention-config=
 
 #metric server and cacher
-graphouse.cacher.host=localhost
+graphouse.cacher.host=0.0.0.0
 graphouse.cacher.port=2003
 graphouse.cacher.threads=100
 graphouse.cacher.socket-timeout-millis=42000

--- a/src/main/resources/graphouse-default.properties
+++ b/src/main/resources/graphouse-default.properties
@@ -31,7 +31,7 @@ graphouse.cacher.max-batch-time-seconds=5
 graphouse.cacher.max-output-threads=5
 
 #Http server (metric search, ping, metricData)
-graphouse.http.host=::
+graphouse.http.bind-address=::
 graphouse.http.port=2005
 graphouse.http.threads=25
 


### PR DESCRIPTION
I think it would be more correct in the settings to offer the choice of the host, to which bind the metric catcher and the web interface.