### PR TITLE
Adding Graphite-api finder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ distributions {
             from('src/main/pySources/graphouse.py') {
                 into 'bin'
             }
+            from('src/main/pySources/graphouse_api.py') {
+                into 'bin'
+            }
             from('LICENSE') {
                 into ''
             }

--- a/doc/install.md
+++ b/doc/install.md
@@ -196,3 +196,23 @@ STORAGE_FINDERS = (
 - Restart graphite-web
 
 
+Graphite-api
+------------
+[Graphite-API](https://graphite-api.readthedocs.io/en/latest/) is an alternative to Graphite-web, without any built-in dashboard. Its role is solely to fetch metrics from a time-series database (in our case - Graphouse) and rendering graphs or JSON data out of these time series. It is meant to be consumed by any of the numerous Graphite dashboard applications.
+
+- Install [graphite-api](https://github.com/brutasse/graphite-api), if you don't have it already. You don't need carbon or whisper, Graphouse and ClickHouse completely replace them.
+- Add graphouse plugin `/opt/graphouse/bin/graphouse_api.py` to your graphite-api finders dir.
+For example, if you dir is `/usr/local/lib/python3.6/site-packages/graphite_api/finders` use command below
+```bash
+sudo ln -fs /opt/graphouse/bin/graphouse_api.py /usr/local/lib/python3.6/site-packages/graphite_api/finders/graphouse_api.py
+```
+
+- Configure storage finder in your [/etc/graphite-api.yaml](https://graphite-api.readthedocs.io/en/latest/configuration.html#etc-graphite-api-yaml)
+```python
+finders:
+  - graphite_api.finders.graphouse_api.GraphouseFinder 
+graphouse:
+  url: http://localhost:2005
+```
+(do not forget to change graphouse URL if needed)
+- Restart graphite-api

--- a/src/main/pySources/graphouse_api.py
+++ b/src/main/pySources/graphouse_api.py
@@ -1,0 +1,113 @@
+import json
+import time
+import traceback
+import urllib.parse
+import requests
+
+from structlog import get_logger
+from graphite_api.intervals import IntervalSet, Interval
+from graphite_api.node import LeafNode, BranchNode
+
+logger = get_logger()
+
+class GraphouseFinder(object):
+    def __init__(self, config):
+        config.setdefault('graphouse', {})
+        self.graphouse_url = config['graphouse'].get('url', 'http://localhost:2005')
+
+    def find_nodes(self, query):
+        request = requests.get('%s/search?%s' % (self.graphouse_url, urllib.parse.urlencode({'query': query.pattern})))
+        request.raise_for_status()
+        result = request.text.split('\n')
+
+        for metric in result:
+            if not metric:
+                continue
+            if metric.endswith('.'):
+                yield BranchNode(metric[:-1])
+            else:
+                yield LeafNode(metric, GraphouseReader(metric, self.graphouse_url))
+
+
+# Data reader
+class GraphouseReader(object):
+    __slots__ = ('path', 'nodes', 'reqkey', 'graphouse_url')
+
+    def __init__(self, path, reqkey='empty', graphouse_url='http://localhost:2005'):
+        self.nodes = [self]
+        self.path = None
+        self.graphouse_url = graphouse_url
+
+        if hasattr(path, '__iter__'):
+            self.nodes = path
+        else:
+            self.path = path
+
+        self.reqkey = reqkey
+
+    """
+    Graphite method
+    Hints graphite-web about the time range available for this given metric in the database
+    """
+
+    def get_intervals(self):
+        return IntervalSet([Interval(0, int(time.time()))])
+
+    """
+    Graphite method
+    :return list of 2 elements (time_info, data_points)
+    time_info - list of 3 elements (start_time, end_time, time_step)
+    data_points - list of ((end_time - start_time) / time_step) points, loaded from database
+    """
+
+    def fetch(self, start_time, end_time):
+        profilingTime = {'start': time.time()}
+
+        try:
+            paths = [node.path.replace('\'', '\\\'') for node in self.nodes]
+
+            query = urllib.parse.urlencode(
+                {
+                    'metrics': ','.join(paths),
+                    'start': start_time,
+                    'end': end_time,
+                    'reqKey': self.reqkey
+                })
+            request_url = self.graphouse_url + "/metricData"
+            request = requests.post(request_url, params=query)
+
+            log.info('DEBUG:graphouse_data_query: %s parameters %s' % (request_url, query))
+
+            request.raise_for_status()
+        except Exception as e:
+            log.info("Failed to fetch data, got exception:\n %s" % traceback.format_exc())
+            raise e
+
+        profilingTime['fetch'] = time.time()
+
+        metrics_object = json.loads(request.text)
+        profilingTime['parse'] = time.time()
+
+        time_infos = []
+        points = []
+
+        for node in self.nodes:
+            metric_object = metrics_object.get(node.path)
+            if metric_object is None:
+                time_infos += (0, 0, 1)
+                points += []
+            else:
+                time_infos += (metric_object.get("start"), metric_object.get("end"), metric_object.get("step"))
+                points += metric_object.get("points")
+
+        profilingTime['convert'] = time.time()
+
+        logger.info('DEBUG:graphouse_time:[%s] full = %s fetch = %s, parse = %s, convert = %s' % (
+            self.reqkey,
+            profilingTime['convert'] - profilingTime['start'],
+            profilingTime['fetch'] - profilingTime['start'],
+            profilingTime['parse'] - profilingTime['fetch'],
+            profilingTime['convert'] - profilingTime['parse']
+        ))
+
+        return time_infos, points


### PR DESCRIPTION
Adding [graphite-api](https://graphite-api.readthedocs.io/en/latest/) finder for graphouse.
Please note that there's room for improvements:
1. Now it's mostly copy-paste of original module, but it's hard to make universal one because graphite-api uses python 3, and moving similar code to the library will make installation harder. Both finders can be packed in separate module (e.g. like https://github.com/brutasse/graphite-cyanite/) though
2. Implementing [fetch_multi()](https://github.com/brutasse/graphite-api/blob/master/docs/finders.rst#fetching-multiple-paths-at-once) for Graphouse in much more interesting. E.g. see how it's done in Cyanite reader - https://github.com/brutasse/graphite-cyanite/blob/master/cyanite.py