### PR TITLE
Fixing Python 3 incompatibility in graphouse_api.py

### DIFF
--- a/src/main/pySources/graphouse_api.py
+++ b/src/main/pySources/graphouse_api.py
@@ -38,7 +38,14 @@ class GraphouseReader(object):
         self.path = None
         self.graphouse_url = graphouse_url
 
-        if hasattr(path, '__iter__'):
+        try:
+            iterator = iter(theElement)
+        except TypeError:
+            # not iterable
+        else:
+            # iterable
+        
+        if hasattr(path, '__iter__') and type(path) != str:
             self.nodes = path
         else:
             self.path = path

--- a/src/main/pySources/graphouse_api.py
+++ b/src/main/pySources/graphouse_api.py
@@ -38,13 +38,6 @@ class GraphouseReader(object):
         self.path = None
         self.graphouse_url = graphouse_url
 
-        try:
-            iterator = iter(theElement)
-        except TypeError:
-            # not iterable
-        else:
-            # iterable
-        
         if hasattr(path, '__iter__') and type(path) != str:
             self.nodes = path
         else:
@@ -118,3 +111,4 @@ class GraphouseReader(object):
         ))
 
         return time_infos, points
+


### PR DESCRIPTION
graphite api also working with python 3, but `hasattr(path, '__iter__')` will be `True` for strings in python 3!
`type(path) != str` will work for python 2.7 and 3.x btw