### PR TITLE
fix an error with rendering images

### DIFF
--- a/src/main/pySources/graphouse.py
+++ b/src/main/pySources/graphouse.py
@@ -95,7 +95,7 @@ class GraphouseReader(object):
             if metric_object is None:
                 if len(self.nodes) == 1:
                     return None
-                time_infos += (0, 0, 1)
+                time_infos += (start_time, end_time, 1)
                 points += []
             else:
                 time_infos += (metric_object.get("start"), metric_object.get("end"), metric_object.get("step"))


### PR DESCRIPTION
graphite-web sets startTime of image as min of all node.start
https://github.com/graphite-project/graphite-web/blob/1.0.2/webapp/graphite/render/glyph.py#L939
So, if you return 0 as node start_time, you will receive wrong image start_time