### PR TITLE
Add support for float timestamp values

### DIFF
--- a/src/main/java/ru/yandex/market/graphouse/server/MetricFactory.java
+++ b/src/main/java/ru/yandex/market/graphouse/server/MetricFactory.java
@@ -73,7 +73,7 @@ public class MetricFactory {
             if (!Double.isFinite(value)) {
                 return null;
             }
-            int timeSeconds = Integer.valueOf(splits[2]);
+            int timeSeconds = (int) Math.round(Double.parseDouble(splits[2]));
             if (timeSeconds <= 0) {
                 return null;
             }

--- a/src/main/resources/graphouse-default.properties
+++ b/src/main/resources/graphouse-default.properties
@@ -1,7 +1,7 @@
 graphouse.allow-cold-run=false
 
 #Clickhouse
-graphouse.clickhouse.host=172.16.45.77
+graphouse.clickhouse.host=localhost
 graphouse.clickhouse.port=8123
 graphouse.clickhouse.db=graphite
 graphouse.clickhouse.user=

--- a/src/main/resources/graphouse-default.properties
+++ b/src/main/resources/graphouse-default.properties
@@ -1,7 +1,7 @@
 graphouse.allow-cold-run=false
 
 #Clickhouse
-graphouse.clickhouse.host=localhost
+graphouse.clickhouse.host=172.16.45.77
 graphouse.clickhouse.port=8123
 graphouse.clickhouse.db=graphite
 graphouse.clickhouse.user=


### PR DESCRIPTION
Some collectD plugins and prometheus adapter sends timestamps as a float. 