### PR TITLE
Support utf-8 metric names with correct encoding of them in RowBinary format

### DIFF
--- a/src/main/java/ru/yandex/market/graphouse/search/tree/MetricBase.java
+++ b/src/main/java/ru/yandex/market/graphouse/search/tree/MetricBase.java
@@ -44,7 +44,7 @@ public abstract class MetricBase implements MetricDescription {
 
     @Override
     public int getNameLength() {
-        int length = name.length();
+        int length = name.getBytes().length;
         if (isDir()) {
             length++;
         }


### PR DESCRIPTION
Replaces String.length() with getBytes().length.
Without it, encoding into RowBinary format declares less bytes as lenght of string, and decoding on ClickHouse side fails.

I beleive that since MetricBase::getNameLength() is only used in MetricRowBinaryHttpEntity::writeMetric(), there is no need to create separate getBinaryNameLength() method, and it is fine to patch getNameLength().

Also, this pull-request lacks tests, but I'm not at all good at this.