### PR TITLE
Fix for case when clickhouse have no data for requested timespan

### DIFF
--- a/src/main/java/ru/yandex/market/graphouse/data/MetricDataService.java
+++ b/src/main/java/ru/yandex/market/graphouse/data/MetricDataService.java
@@ -84,7 +84,6 @@ public class MetricDataService {
         );
         handler.finish();
 	Set<String> handledMetrics = handler.metrics();
-	log.info(handledMetrics);
 	for(MetricName nm: metrics) {
 	    String m = nm.getName();
 	    boolean handled = handledMetrics.contains(m);


### PR DESCRIPTION
If you query graphouse for a metrics in timespan where clickhouse contains no data you will receive empty set `{}` as response, which lead to wrong response `metricname,0,0,1|` when graphouse used with graphite-api.

Here is sample output for unpatched graphouse:

`root@# curl 'localhost:2005/metricData?metrics=metric&start=1526697848&end=1526698448'; echo
{}`

For patched version:

`root@# curl 'localhost:2035/metricData?metrics=metric&start=1526697848&end=1526698448'; echo
{"metric":{"start":1526697840,"end":1526698440,"step":60,"points":[null,null,null,null,null,null,null,null,null,null]}}`

Please accept this PR as this bug confuse grafana in some cases.

Thanks