### PR TITLE
Remove GC logging parameters from default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,9 +100,6 @@ distributions {
 applicationDefaultJvmArgs = [
     '-Dapp.home=GRAPHOUSE_APP_HOME',
     '-Dlog4j.configurationFile=GRAPHOUSE_APP_HOME/conf/log4j2.xml',
-    '-verbose:gc', '-XX:+PrintGC', '-XX:+PrintGCDetails', '-XX:+PrintGCTimeStamps', '-XX:+PrintGCDateStamps',
-    '-XX:+UseGCLogFileRotation', '-XX:NumberOfGCLogFiles=7', '-XX:GCLogFileSize=50M',
-    '-Xloggc:GRAPHOUSE_APP_HOME/log/graphouse.gc.log',
     '-XX:+HeapDumpOnOutOfMemoryError', '-XX:HeapDumpPath=GRAPHOUSE_APP_HOME/log/',
     '-showversion', '-server', '-XX:+UseCompressedOops',
     '-Dsun.net.inetaddr.ttl=60', '-Dsun.net.inetaddr.negative.ttl=0'

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ startScripts {
         unixScript.text = unixScript.text.replace(
             'APP_HOME="`pwd -P`"',
             'APP_HOME="`pwd -P`"\n' +
-                'GRAPHOUSE_OPTS=$(cat $APP_HOME/conf/graphouse.vmoptions)'
+                'GRAPHOUSE_OPTS=$(cat $APP_HOME/conf/*.vmoptions)'
         )
         delete windowsScript
     }

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,23 @@ applicationDefaultJvmArgs = [
 
 startScripts {
     doLast {
+        // Make a version dependent GC logging
+        unixScript.text = unixScript.text.replace(
+            '# Collect all arguments for the java command, following the shell quoting and substitution rules\n',
+            '''\
+            GC_LOG_FILE=GRAPHOUSE_APP_HOME/log/graphouse.gc.log
+            MODERN_GC_SUPPORTED="$JAVACMD -Xlog:gc -version 1>/dev/null 2>&1"
+            LEGACY_GC_SUPPORTED="$JAVACMD -XX:+PrintGCDateStamps -version 1>/dev/null 2>&1"
+            if eval $MODERN_GC_SUPPORTED && eval ! $LEGACY_GC_SUPPORTED; then
+                GC_LOGGING_OPTIONS="-Xlog:gc*:file=${GC_LOG_FILE}:time:filecount=7,filesize=50M"
+            elif eval $LEGACY_GC_SUPPORTED && eval ! $MODERN_GC_SUPPORTED
+                GC_LOGGING_OPTIONS="-verbose:gc -XX:+PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=7 -XX:GCLogFileSize=50M -Xloggc:${GC_LOG_FILE}"
+            fi
+            GRAPHOUSE_OPTS="${GRAPHOUSE_OPTS} ${GC_LOGGING_OPTIONS}"
+
+            # Collect all arguments for the java command, following the shell quoting and substitution rules
+            '''.stripIndent()
+        )
         unixScript.text = unixScript.text.replace('GRAPHOUSE_APP_HOME', '\$APP_HOME')
         unixScript.text = unixScript.text.replace(
             'APP_HOME="`pwd -P`"',

--- a/build.gradle
+++ b/build.gradle
@@ -112,11 +112,11 @@ startScripts {
             '# Collect all arguments for the java command, following the shell quoting and substitution rules\n',
             '''\
             GC_LOG_FILE=GRAPHOUSE_APP_HOME/log/graphouse.gc.log
-            MODERN_GC_SUPPORTED="$JAVACMD -Xlog:gc -version 1>/dev/null 2>&1"
-            LEGACY_GC_SUPPORTED="$JAVACMD -XX:+PrintGCDateStamps -version 1>/dev/null 2>&1"
-            if eval $MODERN_GC_SUPPORTED && eval ! $LEGACY_GC_SUPPORTED; then
+            UNIFIED_JVM_LOGGING="$JAVACMD -Xlog:gc -version 1>/dev/null 2>&1"
+            LEGACY_JVM_LOGGING="$JAVACMD -XX:+PrintGCDateStamps -version 1>/dev/null 2>&1"
+            if eval $UNIFIED_JVM_LOGGING && eval ! $LEGACY_JVM_LOGGING; then
                 GC_LOGGING_OPTIONS="-Xlog:gc*:file=${GC_LOG_FILE}:time:filecount=7,filesize=50M"
-            elif eval $LEGACY_GC_SUPPORTED && eval ! $MODERN_GC_SUPPORTED
+            elif eval $LEGACY_JVM_LOGGING && eval ! $UNIFIED_JVM_LOGGING
                 GC_LOGGING_OPTIONS="-verbose:gc -XX:+PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=7 -XX:GCLogFileSize=50M -Xloggc:${GC_LOG_FILE}"
             fi
             GRAPHOUSE_OPTS="${GRAPHOUSE_OPTS} ${GC_LOGGING_OPTIONS}"
@@ -128,7 +128,7 @@ startScripts {
         unixScript.text = unixScript.text.replace(
             'APP_HOME="`pwd -P`"',
             'APP_HOME="`pwd -P`"\n' +
-                'GRAPHOUSE_OPTS=$(cat $APP_HOME/conf/*.vmoptions)'
+                'GRAPHOUSE_OPTS=$(cat $APP_HOME/conf/graphouse.vmoptions)'
         )
         delete windowsScript
     }


### PR DESCRIPTION
The most of parameters `PrintGC*` was removed from `java` arguments since [jdk9](https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-BE93ABDC-999C-4CB5-A88B-1994AAAC74D5) (search for `PrintGC`) and now the initial script is incompatible with latest JDK versions. This PR removes this incompatibility and make GC logging off by default.