### PR TITLE
Fix overriding dh_build instead of dh_auto_build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,9 +11,9 @@ override_dh_clean:
 	dh_clean
 	./gradlew $(GRADLE_FLAGS) clean
 
-override_dh_build:
+override_dh_auto_build:
 	./gradlew $(GRADLE_FLAGS) build
-	dh_build
+	dh_auto_build
 
 override_dh_install:
 	./gradlew $(GRADLE_FLAGS) installDist


### PR DESCRIPTION
By the coincident, it did work before, but we should override the [existing helper](https://manpages.debian.org/jessie/debhelper/dh_auto_build.1.en.html) instead of nothing.

Output snippet

```
# before
…
dh build
   dh_testdir
   dh_update_autotools_config
   dh_auto_configure
   dh_auto_build
   dh_auto_test
   create-stamp debian/debhelper-build-stamp
 fakeroot debian/rules binary
dh binary
…
# after
…
dh build
   dh_testdir
   dh_update_autotools_config
   dh_auto_configure
   debian/rules override_dh_auto_build
make[1]: Entering directory '/home/felixoid/OPT/Felixoid/github/yandex/graphouse'
./gradlew --gradle-user-home debian/.gradlehome build
Starting a Gradle Daemon, 1 incompatible and 1 stopped Daemons could not be reused, use --status for details
> Task :insertPerfTest
> Task :compileJava
> Task :processResources
> Task :classes
> Task :jar
> Task :startScripts
> Task :distTar
> Task :distZip
> Task :assemble
> Task :compileTestJava
> Task :processTestResources
> Task :testClasses
> Task :test
> Task :check
> Task :build

BUILD SUCCESSFUL in 16s
10 actionable tasks: 10 executed
dh_auto_build
make[1]: Leaving directory '/home/felixoid/OPT/Felixoid/github/yandex/graphouse'
   dh_auto_test
   create-stamp debian/debhelper-build-stamp
 fakeroot debian/rules binary
dh binary
…
```